### PR TITLE
Add a class and some associated functions for affine transformation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(geomlib VERSION 0.0.4 LANGUAGES C CXX)
+project(geomlib VERSION 0.1.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/affine.hpp
+++ b/include/affine.hpp
@@ -1,0 +1,127 @@
+#pragma once
+#ifndef GEOMLIB_AFFINE_HPP
+#define GEOMLIB_AFFINE_HPP
+
+#include <cstdint>
+#include "../third_party/lalib/include/vec.hpp"
+#include "../third_party/lalib/include/mat.hpp"
+
+namespace geomlib {
+
+template<size_t N>
+struct Affine {
+public:
+    Affine(const lalib::MatD<N, N>& c, const lalib::VecD<N>& b) noexcept;
+    Affine(const lalib::MatD<N, N>& c, lalib::VecD<N>&& b) noexcept;
+    Affine(lalib::MatD<N, N>&& c, const lalib::VecD<N>& b) noexcept;
+    Affine(lalib::MatD<N, N>&& c, lalib::VecD<N>&& b) noexcept;
+
+    auto transform(const lalib::VecD<N>& vec, lalib::VecD<N>& rslt) const noexcept -> lalib::VecD<N>&;
+    auto transform(const lalib::DynVecD& vec, lalib::DynVecD& rslt) const noexcept -> lalib::DynVecD&;
+
+private:
+    lalib::MatD<N, N> _c;
+    lalib::VecD<N> _b;
+};
+
+template<size_t N, size_t AXIS>
+auto rotate(double angle) noexcept -> Affine<N> = delete;
+
+template<size_t N>
+auto translate(const lalib::VecD<N>& p) noexcept -> Affine<N>;
+
+template<size_t N>
+auto translate(lalib::VecD<N>&& p) noexcept -> Affine<N>;
+
+
+// ###### Implementations ####### //
+
+template <size_t N>
+inline Affine<N>::Affine(const lalib::MatD<N, N> &c, const lalib::VecD<N> &b) noexcept:
+    _c(c), _b(b)
+{ }
+
+template <size_t N>
+inline Affine<N>::Affine(lalib::MatD<N, N> &&c, const lalib::VecD<N> &b) noexcept:
+    _c(std::move(c)), _b(b)
+{ }
+
+template <size_t N>
+inline Affine<N>::Affine(const lalib::MatD<N, N> &c, lalib::VecD<N> &&b) noexcept:
+    _c(c), _b(std::move(b))
+{ }
+
+template <size_t N>
+inline Affine<N>::Affine(lalib::MatD<N, N> &&c, lalib::VecD<N> &&b) noexcept:
+    _c(std::move(c)), _b(std::move(b))
+{ }
+
+template <size_t N>
+inline auto Affine<N>::transform(const lalib::VecD<N>& vec, lalib::VecD<N>& rslt) const noexcept -> lalib::VecD<N>& {
+    lalib::mul(1.0, this->_c, vec, 0.0, rslt);
+    lalib::add(rslt, this->_b, rslt);
+    return rslt;
+}
+
+template <size_t N>
+inline auto Affine<N>::transform(const lalib::DynVecD& vec, lalib::DynVecD& rslt) const noexcept -> lalib::DynVecD& {
+    lalib::mul(1.0, this->_c, vec, 0.0, rslt);
+    lalib::add(rslt, this->_b, rslt);
+    return rslt;
+}
+
+
+template<>
+inline auto rotate<2, 1>(double angle) noexcept -> Affine<2> {
+    auto mat = lalib::MatD<2, 2>({
+        std::cos(angle),    -std::sin(angle),
+        std::sin(angle),    std::cos(angle) 
+    });
+    return Affine<2>(std::move(mat), lalib::VecD<2>::filled(0.0));
+}
+
+template<>
+inline auto rotate<3, 1>(double angle) noexcept -> Affine<3> {
+    auto mat = lalib::MatD<3, 3>({
+        1.0,    0.0,                0.0,
+        0.0,    std::cos(angle),    -std::sin(angle),
+        0.0,    std::sin(angle),    std::cos(angle) 
+    });
+    return Affine<3>(std::move(mat), lalib::VecD<3>::filled(0.0));
+}
+
+template<>
+inline auto rotate<3, 2>(double angle) noexcept -> Affine<3> {
+    auto mat = lalib::MatD<3, 3>({
+        std::cos(angle),    0.0,    std::sin(angle),
+        0.0,                1.0,    0.0,
+        -std::sin(angle),   0.0,    std::cos(angle) 
+    });
+    return Affine<3>(std::move(mat), lalib::VecD<3>::filled(0.0));
+}
+
+template<>
+inline auto rotate<3, 3>(double angle) noexcept -> Affine<3> {
+    auto mat = lalib::MatD<3, 3>({
+        std::cos(angle),    -std::sin(angle),   0.0,
+        std::sin(angle),    std::cos(angle),    0.0,
+        0.0,                0.0,                1.0,
+    });
+    return Affine<3>(std::move(mat), lalib::VecD<3>::filled(0.0));
+}
+
+template<size_t N>
+inline auto translate(const lalib::VecD<N>& p) noexcept -> Affine<2> {
+    auto affine = Affine<N>(lalib::MatD<N, N>::diag(1.0), p);
+    return affine;
+}
+
+template<size_t N>
+inline auto translate(lalib::VecD<N>&& p) noexcept -> Affine<2> {
+    auto affine = Affine<N>(lalib::MatD<N, N>::diag(1.0), std::move(p));
+    return affine;
+}
+
+}
+
+#endif

--- a/include/affine.hpp
+++ b/include/affine.hpp
@@ -72,7 +72,7 @@ inline auto Affine<N>::transform(const lalib::DynVecD& vec, lalib::DynVecD& rslt
 
 
 template<>
-inline auto rotate<2, 1>(double angle) noexcept -> Affine<2> {
+inline auto rotate<2, 0>(double angle) noexcept -> Affine<2> {
     auto mat = lalib::MatD<2, 2>({
         std::cos(angle),    -std::sin(angle),
         std::sin(angle),    std::cos(angle) 
@@ -81,7 +81,7 @@ inline auto rotate<2, 1>(double angle) noexcept -> Affine<2> {
 }
 
 template<>
-inline auto rotate<3, 1>(double angle) noexcept -> Affine<3> {
+inline auto rotate<3, 0>(double angle) noexcept -> Affine<3> {
     auto mat = lalib::MatD<3, 3>({
         1.0,    0.0,                0.0,
         0.0,    std::cos(angle),    -std::sin(angle),
@@ -91,7 +91,7 @@ inline auto rotate<3, 1>(double angle) noexcept -> Affine<3> {
 }
 
 template<>
-inline auto rotate<3, 2>(double angle) noexcept -> Affine<3> {
+inline auto rotate<3, 1>(double angle) noexcept -> Affine<3> {
     auto mat = lalib::MatD<3, 3>({
         std::cos(angle),    0.0,    std::sin(angle),
         0.0,                1.0,    0.0,
@@ -101,7 +101,7 @@ inline auto rotate<3, 2>(double angle) noexcept -> Affine<3> {
 }
 
 template<>
-inline auto rotate<3, 3>(double angle) noexcept -> Affine<3> {
+inline auto rotate<3, 2>(double angle) noexcept -> Affine<3> {
     auto mat = lalib::MatD<3, 3>({
         std::cos(angle),    -std::sin(angle),   0.0,
         std::sin(angle),    std::cos(angle),    0.0,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,3 +5,7 @@ gtest_discover_tests(segment_test)
 add_executable(cubic_spline_test curve/cubic_spline.cc)
 target_link_libraries(cubic_spline_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
 gtest_discover_tests(cubic_spline_test)
+
+add_executable(affine_test ./affine.cc)
+target_link_libraries(affine_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
+gtest_discover_tests(affine_test)

--- a/test/affine.cc
+++ b/test/affine.cc
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+#include <numbers>
+#include "../include/affine.hpp"
+
+TEST(AffineTests, Rotation2DTest) {
+    const auto affine = geomlib::rotate<2, 1>(std::numbers::pi / 6.0);
+    auto ex = lalib::VecD<2>({ 1.0, 0.0 });
+    auto ey = lalib::VecD<2>({ 0.0, 1.0 });
+    
+    affine.transform(ex, ex);
+    affine.transform(ey, ey);
+
+    ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ex[0]);
+    ASSERT_DOUBLE_EQ(0.5 , ex[1]);
+
+    ASSERT_DOUBLE_EQ(-0.5 , ey[0]);
+    ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ey[1]);
+}
+
+TEST(AffineTests, Rotation3DXTest) {
+    const auto affine = geomlib::rotate<3, 1>(std::numbers::pi / 6.0);
+    auto ex = lalib::VecD<3>({ 1.0, 0.0, 0.0 });
+    auto ey = lalib::VecD<3>({ 0.0, 1.0, 0.0 });
+    auto ez = lalib::VecD<3>({ 0.0, 0.0, 1.0 });
+    
+    affine.transform(ex, ex);
+    affine.transform(ey, ey);
+    affine.transform(ez, ez);
+
+    ASSERT_DOUBLE_EQ(1.0, ex[0]);
+    ASSERT_DOUBLE_EQ(0.0, ex[1]);
+    ASSERT_DOUBLE_EQ(0.0, ex[2]);
+
+    ASSERT_DOUBLE_EQ(0.0 , ey[0]);
+    ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ey[1]);
+    ASSERT_DOUBLE_EQ(0.5 , ey[2]);
+
+    ASSERT_DOUBLE_EQ(0.0 , ez[0]);
+    ASSERT_DOUBLE_EQ(-0.5 , ez[1]);
+    ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ez[2]);
+}
+
+TEST(AffineTests, Rotation3DYTest) {
+    const auto affine = geomlib::rotate<3, 2>(std::numbers::pi / 6.0);
+    auto ex = lalib::VecD<3>({ 1.0, 0.0, 0.0 });
+    auto ey = lalib::VecD<3>({ 0.0, 1.0, 0.0 });
+    auto ez = lalib::VecD<3>({ 0.0, 0.0, 1.0 });
+    
+    affine.transform(ex, ex);
+    affine.transform(ey, ey);
+    affine.transform(ez, ez);
+
+    ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ex[0]);
+    ASSERT_DOUBLE_EQ(0.0 , ex[1]);
+    ASSERT_DOUBLE_EQ(-0.5 , ex[2]);
+
+    ASSERT_DOUBLE_EQ(0.0, ey[0]);
+    ASSERT_DOUBLE_EQ(1.0, ey[1]);
+    ASSERT_DOUBLE_EQ(0.0, ey[2]);
+
+    ASSERT_DOUBLE_EQ(0.5 , ez[0]);
+    ASSERT_DOUBLE_EQ(0.0 , ez[1]);
+    ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ez[2]);
+}
+
+TEST(AffineTests, Rotation3DZTest) {
+    const auto affine = geomlib::rotate<3, 3>(std::numbers::pi / 6.0);
+    auto ex = lalib::VecD<3>({ 1.0, 0.0, 0.0 });
+    auto ey = lalib::VecD<3>({ 0.0, 1.0, 0.0 });
+    auto ez = lalib::VecD<3>({ 0.0, 0.0, 1.0 });
+    
+    affine.transform(ex, ex);
+    affine.transform(ey, ey);
+    affine.transform(ez, ez);
+
+    ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ex[0]);
+    ASSERT_DOUBLE_EQ(0.5 , ex[1]);
+    ASSERT_DOUBLE_EQ(0.0 , ex[2]);
+
+    ASSERT_DOUBLE_EQ(-0.5 , ey[0]);
+    ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ey[1]);
+    ASSERT_DOUBLE_EQ(0.0 , ey[2]);
+
+    ASSERT_DOUBLE_EQ(0.0, ez[0]);
+    ASSERT_DOUBLE_EQ(0.0, ez[1]);
+    ASSERT_DOUBLE_EQ(1.0, ez[2]);
+}

--- a/test/affine.cc
+++ b/test/affine.cc
@@ -3,7 +3,7 @@
 #include "../include/affine.hpp"
 
 TEST(AffineTests, Rotation2DTest) {
-    const auto affine = geomlib::rotate<2, 1>(std::numbers::pi / 6.0);
+    const auto affine = geomlib::rotate<2, 0>(std::numbers::pi / 6.0);
     auto ex = lalib::VecD<2>({ 1.0, 0.0 });
     auto ey = lalib::VecD<2>({ 0.0, 1.0 });
     
@@ -18,7 +18,7 @@ TEST(AffineTests, Rotation2DTest) {
 }
 
 TEST(AffineTests, Rotation3DXTest) {
-    const auto affine = geomlib::rotate<3, 1>(std::numbers::pi / 6.0);
+    const auto affine = geomlib::rotate<3, 0>(std::numbers::pi / 6.0);
     auto ex = lalib::VecD<3>({ 1.0, 0.0, 0.0 });
     auto ey = lalib::VecD<3>({ 0.0, 1.0, 0.0 });
     auto ez = lalib::VecD<3>({ 0.0, 0.0, 1.0 });
@@ -41,7 +41,7 @@ TEST(AffineTests, Rotation3DXTest) {
 }
 
 TEST(AffineTests, Rotation3DYTest) {
-    const auto affine = geomlib::rotate<3, 2>(std::numbers::pi / 6.0);
+    const auto affine = geomlib::rotate<3, 1>(std::numbers::pi / 6.0);
     auto ex = lalib::VecD<3>({ 1.0, 0.0, 0.0 });
     auto ey = lalib::VecD<3>({ 0.0, 1.0, 0.0 });
     auto ez = lalib::VecD<3>({ 0.0, 0.0, 1.0 });
@@ -64,7 +64,7 @@ TEST(AffineTests, Rotation3DYTest) {
 }
 
 TEST(AffineTests, Rotation3DZTest) {
-    const auto affine = geomlib::rotate<3, 3>(std::numbers::pi / 6.0);
+    const auto affine = geomlib::rotate<3, 2>(std::numbers::pi / 6.0);
     auto ex = lalib::VecD<3>({ 1.0, 0.0, 0.0 });
     auto ey = lalib::VecD<3>({ 0.0, 1.0, 0.0 });
     auto ez = lalib::VecD<3>({ 0.0, 0.0, 1.0 });


### PR DESCRIPTION
# Overview
This pull request introduces a class representing affine transformation, and some associated functions to make it easy to generate an affine transformation class.

### A Class
* `Affine`: represents an affine transformation and provides a method to apply the transformation to the given vector.

### Associated Global Functions
* `rotate<N, AXIS>(angle)`: generates the instance of affine transformation that represents the rotation of a given `angle`. The rotation direction is determined by the sign of the `angle` that follows the right-hand rule ( positive value indicates CCW ). `N` is the dimension of the transformation and `AXIS` specifies the rotation axis.`N` can be specified with 2 or 3. If `N == 2`, `AXIS` must be 0, otherwise, `AXIS` can be specified with 0 to 2 ( 0 is the x-axis, 2 is the z-axis).
* `translate<N>(p)`: generates the instance of affine transformation that represents the translation. The direction and the magnitude is specified by `p`.