### PR TITLE
Introduce some APIs for convenience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(geomlib VERSION 0.1.0 LANGUAGES C CXX)
+project(geomlib VERSION 0.2.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/affine.hpp
+++ b/include/affine.hpp
@@ -38,7 +38,12 @@ public:
     Affine(lalib::MatD<N, N>&& c, lalib::VecD<N>&& b) noexcept;
 
     auto transform(const lalib::VecD<N>& vec, lalib::VecD<N>& rslt) const noexcept -> lalib::VecD<N>&;
+    auto transform(lalib::VecD<N>& vec) const noexcept -> lalib::VecD<N>&;
+    auto transformed(const lalib::VecD<N>& vec) const noexcept -> lalib::VecD<N>;
+
     auto transform(const lalib::DynVecD& vec, lalib::DynVecD& rslt) const noexcept -> lalib::DynVecD&;
+    auto transform(lalib::DynVecD& vec) const noexcept -> lalib::DynVecD&;
+    auto transformed(const lalib::DynVecD& vec) const noexcept -> lalib::DynVecD;
 
 private:
     lalib::MatD<N, N> _c;
@@ -92,15 +97,44 @@ inline auto Affine<N>::transform(const lalib::VecD<N>& vec, lalib::VecD<N>& rslt
 }
 
 template <size_t N>
+inline auto Affine<N>::transform(lalib::VecD<N> &vec) const noexcept -> lalib::VecD<N> &
+{
+    this->transform(vec, vec);
+    return vec;
+}
+
+template <size_t N>
+inline auto Affine<N>::transformed(const lalib::VecD<N> &vec) const noexcept -> lalib::VecD<N>
+{
+    auto p = lalib::VecD<N>::uninit();
+    this->transform(vec, p);
+    return p;
+}
+
+template <size_t N>
 inline auto Affine<N>::transform(const lalib::DynVecD& vec, lalib::DynVecD& rslt) const noexcept -> lalib::DynVecD& {
     lalib::mul(1.0, this->_c, vec, 0.0, rslt);
     lalib::add(rslt, this->_b, rslt);
     return rslt;
 }
 
+template <size_t N>
+inline auto Affine<N>::transform(lalib::DynVecD &vec) const noexcept -> lalib::DynVecD &
+{
+    this->transform(vec, vec);
+    return vec;
+}
+
+template <size_t N>
+inline auto Affine<N>::transformed(const lalib::DynVecD &vec) const noexcept -> lalib::DynVecD
+{
+    auto p = lalib::DynVecD::uninit(N);
+    this->transform(vec, p);
+    return p;
+}
 
 template<>
-inline auto rotate<2, 0>(double angle) noexcept -> Affine<2> {
+[[deprecated]] inline auto rotate<2, 0>(double angle) noexcept -> Affine<2> {
     auto mat = lalib::MatD<2, 2>({
         std::cos(angle),    -std::sin(angle),
         std::sin(angle),    std::cos(angle) 

--- a/include/affine.hpp
+++ b/include/affine.hpp
@@ -48,6 +48,9 @@ private:
 template<size_t N, size_t AXIS>
 auto rotate(double angle) noexcept -> Affine<N> = delete;
 
+auto rotate2d(double angle, const lalib::VecD<2>& pivot) noexcept -> Affine<2>;
+
+
 template<size_t N>
 auto translate(const lalib::VecD<N>& p) noexcept -> Affine<N>;
 
@@ -133,6 +136,16 @@ inline auto rotate<3, 2>(double angle) noexcept -> Affine<3> {
         0.0,                0.0,                1.0,
     });
     return Affine<3>(std::move(mat), lalib::VecD<3>::filled(0.0));
+}
+
+inline auto rotate2d(double angle, const lalib::VecD<2>& pivot) noexcept -> Affine<2> {
+    auto mat = lalib::MatD<2, 2>({
+        std::cos(angle),    -std::sin(angle),
+        std::sin(angle),    std::cos(angle) 
+    });
+    auto p = pivot - mat * pivot;
+
+    return Affine<2>(std::move(mat), std::move(p));
 }
 
 template<size_t N>

--- a/include/curve/curve_concepts.hpp
+++ b/include/curve/curve_concepts.hpp
@@ -16,11 +16,15 @@ concept Curve = requires(const T& t) {
     { t(std::declval<double>()) } -> std::convertible_to<typename T::PointType>;
     { t.point(std::declval<double>()) } -> std::convertible_to<typename T::PointType>;
 
-    // Query to get the length of the curve.
-    { t.length() } -> std::convertible_to<double>;
-
     // Query to get the normalized tangent vector at the specified position.
     { t.tangent(std::declval<double>()) } -> std::convertible_to<typename T::VectorType>;
+};
+
+template<typename T>
+concept LengthMeasurableCurve = Curve<T> &&
+requires(const T& t) {
+    // Query to get the length of the curve.
+    { t.length() } -> std::convertible_to<double>;
 };
 
 }

--- a/test/affine.cc
+++ b/test/affine.cc
@@ -18,6 +18,22 @@ TEST(AffineTests, Rotation2DTest) {
     ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ey[1]);
 }
 
+TEST(AffineTests, Rotation2DWithPivotTest) {
+    auto pivot = lalib::VecD<2>({ 1.0, 0.0 });
+    const auto affine = geomlib::rotate2d(std::numbers::pi / 6.0, pivot);
+    auto zero = lalib::VecD<2>({ 0.0, 0.0 });
+    auto ex = lalib::VecD<2>({ 1.0, 0.0 });
+
+    affine.transform(zero, zero);
+    affine.transform(ex, ex);
+
+    ASSERT_DOUBLE_EQ(1.0 - std::sqrt(3) / 2.0, zero[0]);
+    ASSERT_DOUBLE_EQ(-0.5, zero[1]);
+
+    ASSERT_DOUBLE_EQ(1.0, ex[0]);
+    ASSERT_DOUBLE_EQ(0.0, ex[1]);
+}
+
 TEST(AffineTests, Rotation3DXTest) {
     const auto affine = geomlib::rotate<3, 0>(std::numbers::pi / 6.0);
     auto ex = lalib::VecD<3>({ 1.0, 0.0, 0.0 });

--- a/test/affine.cc
+++ b/test/affine.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <numbers>
 #include "../include/affine.hpp"
+#include "../include/curve/segment.hpp"
 
 TEST(AffineTests, Rotation2DTest) {
     const auto affine = geomlib::rotate<2, 0>(std::numbers::pi / 6.0);
@@ -84,4 +85,20 @@ TEST(AffineTests, Rotation3DZTest) {
     ASSERT_DOUBLE_EQ(0.0, ez[0]);
     ASSERT_DOUBLE_EQ(0.0, ez[1]);
     ASSERT_DOUBLE_EQ(1.0, ez[2]);
+}
+
+TEST(AffineTests, SegmentRotationTest) {
+    auto seg = geomlib::Segment(
+        lalib::VecD<2>({ 0.0, 0.0 }),
+        lalib::VecD<2>({ 1.0, 1.0 })
+    );
+    auto affine = geomlib::rotate<2, 0>(std::numbers::pi / 4.0);
+
+    auto trans_seg = geomlib::transform(std::move(seg), std::move(affine));
+    
+    ASSERT_DOUBLE_EQ(0.0, trans_seg.point(0.0)[0]);
+    ASSERT_DOUBLE_EQ(0.0, trans_seg.point(0.0)[1]);
+
+    ASSERT_NEAR(0.0, trans_seg.point(1.0)[0], 1.0e-14);
+    ASSERT_DOUBLE_EQ(std::sqrt(2.0), trans_seg.point(1.0)[1]);
 }

--- a/test/affine.cc
+++ b/test/affine.cc
@@ -4,12 +4,12 @@
 #include "../include/curve/segment.hpp"
 
 TEST(AffineTests, Rotation2DTest) {
-    const auto affine = geomlib::rotate<2, 0>(std::numbers::pi / 6.0);
+    const auto affine = geomlib::rotate2d(std::numbers::pi / 6.0, lalib::VecD<2>::filled(0.0));
     auto ex = lalib::VecD<2>({ 1.0, 0.0 });
     auto ey = lalib::VecD<2>({ 0.0, 1.0 });
     
     affine.transform(ex, ex);
-    affine.transform(ey, ey);
+    affine.transform(ey);
 
     ASSERT_DOUBLE_EQ(std::sqrt(3) / 2.0 , ex[0]);
     ASSERT_DOUBLE_EQ(0.5 , ex[1]);
@@ -25,7 +25,7 @@ TEST(AffineTests, Rotation2DWithPivotTest) {
     auto ex = lalib::VecD<2>({ 1.0, 0.0 });
 
     affine.transform(zero, zero);
-    affine.transform(ex, ex);
+    ex = affine.transformed(ex);
 
     ASSERT_DOUBLE_EQ(1.0 - std::sqrt(3) / 2.0, zero[0]);
     ASSERT_DOUBLE_EQ(-0.5, zero[1]);
@@ -108,7 +108,7 @@ TEST(AffineTests, SegmentRotationTest) {
         lalib::VecD<2>({ 0.0, 0.0 }),
         lalib::VecD<2>({ 1.0, 1.0 })
     );
-    auto affine = geomlib::rotate<2, 0>(std::numbers::pi / 4.0);
+    auto affine = geomlib::rotate2d(std::numbers::pi / 4.0, lalib::VecD<2>::filled(0.0));
 
     auto trans_seg = geomlib::transform(std::move(seg), std::move(affine));
     


### PR DESCRIPTION
# Overview
This pull request introduces a structure and some member and non-member functions listed below for convenience.

### Structure
* `AffineTransformedCurve`: represents an arbitrary curve type that was applied to any affine transformation.

### Member functions
* `Affine<N>::transform()`: applies the transformation to the vector and overwrite it.
* `Affine<N>::transformed()`: applies the transformation to the vector and returns the operation result with the copy.

### Non-member function
* `rotate2d()`: generates an instance of `Affine<2>` to represent the bidimensional rotation with an arbitral pivot. With the introduction of this function, the function template specialization `rotate<2, 0>()` has been deprecated and will be removed in the future update.