### PR TITLE
[FIX] fix a bug due to typo in `affine.hpp`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(geomlib VERSION 0.2.1 LANGUAGES C CXX)
+project(geomlib VERSION 0.2.2 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/affine.hpp
+++ b/include/affine.hpp
@@ -194,13 +194,13 @@ inline auto rotate2d(double angle, const lalib::VecD<2>& pivot) noexcept -> Affi
 }
 
 template<size_t N>
-inline auto translate(const lalib::VecD<N>& p) noexcept -> Affine<2> {
+inline auto translate(const lalib::VecD<N>& p) noexcept -> Affine<N> {
     auto affine = Affine<N>(lalib::MatD<N, N>::diag(1.0), p);
     return affine;
 }
 
 template<size_t N>
-inline auto translate(lalib::VecD<N>&& p) noexcept -> Affine<2> {
+inline auto translate(lalib::VecD<N>&& p) noexcept -> Affine<N> {
     auto affine = Affine<N>(lalib::MatD<N, N>::diag(1.0), std::move(p));
     return affine;
 }


### PR DESCRIPTION
# Overview
This pull request fixes a bug due to a typo in the function definition of the function template specialization of `translation()`.
Due to the typo, the definition was interpreted as function overload, not function template specialization.
Therefore, when calling this function, the compiler failed due to the ambiguous function existence.