### PR TITLE
Add polyline feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(geomlib VERSION 0.2.2 LANGUAGES C CXX)
+project(geomlib VERSION 0.3.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/curve/cubic_spline.hpp
+++ b/include/curve/cubic_spline.hpp
@@ -33,6 +33,10 @@ public:
     /// @return length of the segment
     auto length() const noexcept -> double;
 
+    /// @brief  Returns the length from starting point to the given `s`.
+    /// @param s 
+    auto length(double s) const noexcept -> double;
+
     auto dp(double s) const noexcept -> VectorType;
 
     /// @brief  Returns the tangent vector
@@ -47,12 +51,15 @@ private:
     static auto __calc_coeffs(const std::vector<PointType>& nodes) noexcept 
         -> std::vector<std::array<VectorType, 4>>;
 
-    auto __search_seg_id(double s) const noexcept -> size_t;
+    auto __get_seg_id(double s) const noexcept -> size_t;
     auto __seg_length(size_t seg_id) const noexcept -> double;
     auto __seg_local_pos(double glob_pos, size_t segid) const noexcept -> double;
 
     auto __calc_seg_p(size_t seg_id, double local_pos) const noexcept -> PointType;
     auto __calc_seg_dp(size_t seg_id, double local_pos) const noexcept -> VectorType;
+
+    template<std::invocable<double> F>
+    static auto __int(double st, double ed, F&& f, size_t n_div) noexcept -> decltype(f(st));
 };
 
 template <size_t N>
@@ -96,7 +103,7 @@ inline auto CubicSpline<N>::operator()(double s) const noexcept -> PointType
 template <size_t N>
 inline auto CubicSpline<N>::point(double s) const noexcept -> PointType
 {
-    auto seg_id = this->__search_seg_id(s);
+    auto seg_id = this->__get_seg_id(s);
     auto local_s = this->__seg_local_pos(s, seg_id);
 
     auto p = this->__calc_seg_p(seg_id, local_s);
@@ -110,9 +117,19 @@ inline auto CubicSpline<N>::length() const noexcept -> double
 }
 
 template <size_t N>
+inline auto CubicSpline<N>::length(double s) const noexcept -> double
+{
+    auto sid = this->__get_seg_id(s);
+    auto seg_s = this->__seg_local_pos(s, sid);
+    auto len = this->_cumul_length[sid];
+    len += __int(0.0, seg_s, [&](double s){ return this->__calc_seg_dp(sid, s).norm2(); }, 10);
+    return len;
+}
+
+template <size_t N>
 inline auto CubicSpline<N>::dp(double s) const noexcept -> VectorType
 {
-    auto seg_id = this->__search_seg_id(s);
+    auto seg_id = this->__get_seg_id(s);
     auto local_s = this->__seg_local_pos(s, seg_id);
 
     auto p = this->__calc_seg_dp(seg_id, local_s);
@@ -197,7 +214,7 @@ inline auto CubicSpline<N>::__calc_coeffs(const std::vector<PointType> &nodes) n
 }
 
 template <size_t N>
-inline auto CubicSpline<N>::__search_seg_id(double s) const noexcept -> size_t
+inline auto CubicSpline<N>::__get_seg_id(double s) const noexcept -> size_t
 {
     s = std::clamp(s, 0.0, 1.0 - std::numeric_limits<double>::epsilon());
     auto n_segs = this->n_segments();
@@ -233,6 +250,26 @@ inline auto CubicSpline<N>::__calc_seg_dp(size_t seg_id, double s) const noexcep
     auto p = this->_c[seg_id][1] + 2.0 * this->_c[seg_id][2] * s + 3.0 * this->_c[seg_id][3] * std::pow(s, 2);
     return p;
 }
+
+template <size_t N>
+template <std::invocable<double> F>
+inline auto CubicSpline<N>::__int(double st, double ed, F &&f, size_t n_div) noexcept -> decltype(f(st))
+{
+    auto ds = ed - st;
+    auto len = decltype(f(std::declval<double>()))();
+    for (auto k = 0u; k <= n_div - 2; k += 2) {
+        const auto s0 = ds * static_cast<double>(k) / n_div + st;
+        const auto s1 = ds * static_cast<double>(k + 1) / n_div + st;
+        const auto s2 = ds * static_cast<double>(k + 2) / n_div + st;
+        const auto f0 = f(s0);
+        const auto f1 = f(s1);
+        const auto f2 = f(s2);
+
+        len += (f0 + 4.0 * f1 + f2) * ds / (3.0 * n_div);
+    }
+    return len;
+}
+
 }
 
 #endif

--- a/include/curve/polyline.hpp
+++ b/include/curve/polyline.hpp
@@ -1,0 +1,161 @@
+#pragma once
+#ifndef GEOMLIB_CURVE_POLYLINE_HPP
+#define GEOMLIB_CURVE_POLYLINE_HPP
+
+#include "../../third_party/lalib/include/vec.hpp"
+#include <array>
+#include <vector>
+#include <cassert>
+
+namespace geomlib {
+
+template<size_t N>
+struct Polyline {
+public:
+    using PointType = lalib::SizedVec<double, N>;
+    using VectorType = lalib::SizedVec<double, N>;
+
+    Polyline(const std::vector<PointType>& nodes);
+    Polyline(std::vector<PointType>&& nodes);
+
+    /// @brief  Returns the number of segments in the polyline
+    /// @return the number of segments
+    auto n_segments() const noexcept -> size_t;
+
+    auto operator()(double s) const noexcept -> PointType;
+
+    /// @brief  Returns the point on the segment specified by the given local position `s`
+    /// @note   `s` is clamped with 0.0 or 1.0 if it is out of range.
+    /// @param s    local position `s` which range is [0.0, 1.0].
+    /// @return     a point on the segment
+    auto point(double s) const noexcept -> PointType;
+
+    /// @brief  Returns the length of the segment.
+    /// @return length of the segment
+    auto length() const noexcept -> double;
+
+    auto dp(double s) const noexcept -> VectorType;
+
+    /// @brief  Returns the tangent vector
+    /// @param s 
+    /// @return 
+    auto tangent(double s) const noexcept -> VectorType;
+
+private:
+    std::vector<double> _cumul_length;
+    std::vector<PointType> _nodes;
+
+    static auto __calc_cumul_length(const std::vector<PointType>& nodes) noexcept -> std::vector<double>;
+    static auto __lerp(const PointType& p1, const PointType& p2, double t) noexcept -> PointType;
+    auto __get_seg_id(double local_pos) const noexcept -> size_t;
+    auto __calc_local_seg_pos(double local_pos, size_t seg_id) const noexcept -> double;
+    auto __calc_seg_len(size_t seg_id) const noexcept -> double;
+};
+
+template <size_t N>
+inline Polyline<N>::Polyline(const std::vector<PointType> &nodes):
+    _cumul_length(__calc_cumul_length(nodes)), _nodes(nodes)
+{ }
+
+template <size_t N>
+inline Polyline<N>::Polyline(std::vector<PointType> &&nodes):
+    _cumul_length(__calc_cumul_length(nodes)), _nodes(std::move(nodes))
+{ }
+
+template <size_t N>
+inline auto Polyline<N>::n_segments() const noexcept -> size_t
+{
+    auto n_seg = this->_nodes.size() - 1;
+    return n_seg;
+}
+
+template <size_t N>
+inline auto Polyline<N>::operator()(double s) const noexcept -> PointType
+{
+    return this->point(s);
+}
+
+template <size_t N>
+inline auto Polyline<N>::point(double s) const noexcept -> PointType
+{
+    auto sid = this->__get_seg_id(s);
+    auto seg_s = this->__calc_local_seg_pos(s, sid);
+    auto p = this->__lerp(this->_nodes[sid], this->_nodes[sid + 1], seg_s);
+    return p;
+}
+
+template <size_t N>
+inline auto Polyline<N>::length() const noexcept -> double
+{
+    return this->_cumul_length.back();
+}
+
+template <size_t N>
+inline auto Polyline<N>::dp(double s) const noexcept -> VectorType
+{
+    auto sid = this->__get_seg_id(s);
+    auto seg_s = this->__calc_local_seg_pos(s, sid);
+    auto dp = (this->_nodes[sid + 1] - this->_nodes[sid]) / this->__calc_seg_len(sid);
+    return dp;
+}
+
+template <size_t N>
+inline auto Polyline<N>::tangent(double s) const noexcept -> VectorType
+{
+    auto dp = this->dp(s);
+    dp = dp / dp.norm2();
+    return dp;
+}
+
+template <size_t N>
+inline auto Polyline<N>::__calc_cumul_length(const std::vector<PointType> &nodes) noexcept -> std::vector<double>
+{
+    double total_len = 0.0;
+    auto cumul_len = std::vector<double>();
+    cumul_len.emplace_back(0.0);
+    for (auto i = 1u; i < nodes.size(); ++i) {
+        auto len = (nodes[i] - nodes[i - 1]).norm2();
+        total_len += len;
+        cumul_len.emplace_back(total_len);
+    }
+    return cumul_len;
+}
+
+template <size_t N>
+inline auto Polyline<N>::__lerp(const PointType &p1, const PointType &p2, double t) noexcept -> PointType
+{
+    return p1 + t * (p2 - p1);
+}
+
+template <size_t N>
+inline auto Polyline<N>::__calc_local_seg_pos(double local_pos, size_t seg_id) const noexcept -> double
+{
+    assert(seg_id < this->n_segments());
+    auto seg_len = this->__calc_seg_len(seg_id);
+    auto s = (local_pos * this->length() - this->_cumul_length[seg_id]) / seg_len;
+    return s;
+}
+
+template <size_t N>
+inline auto Polyline<N>::__calc_seg_len(size_t seg_id) const noexcept -> double
+{
+    auto seg_len = this->_cumul_length[seg_id + 1] - this->_cumul_length[seg_id];
+    return seg_len;
+}
+
+template <size_t N>
+inline auto Polyline<N>::__get_seg_id(double local_pos) const noexcept -> size_t
+{
+    local_pos = std::clamp(local_pos, 0.0, 1.0);
+    auto len = this->length();
+    for (auto i = 1u; i < this->_cumul_length.size(); ++i) {
+        if (local_pos * len < this->_cumul_length[i]) {
+            return i - 1;
+        }
+    }
+    return this->n_segments() - 1;  // the last segment
+}
+
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,10 @@ add_executable(cubic_spline_test curve/cubic_spline.cc)
 target_link_libraries(cubic_spline_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
 gtest_discover_tests(cubic_spline_test)
 
+add_executable(polyline_test curve/polyline.cc)
+target_link_libraries(polyline_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
+gtest_discover_tests(polyline_test)
+
 add_executable(affine_test ./affine.cc)
 target_link_libraries(affine_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
 gtest_discover_tests(affine_test)

--- a/test/curve/cubic_spline.cc
+++ b/test/curve/cubic_spline.cc
@@ -42,6 +42,20 @@ TEST_F(SplineTests, LengthTest) {
 	ASSERT_NEAR(std::sqrt(2), curve.length(), 1e-10);
 }
 
+TEST_F(SplineTests, InterLengthTest) {
+	auto curve = geomlib::CubicSpline<2>({
+		lalib::VecD<2>({ 0.0, 0.0 }),
+		lalib::VecD<2>({ 0.2, 0.0 }),
+		lalib::VecD<2>({ 0.4, 0.0 }),
+		lalib::VecD<2>({ 0.6, 0.0 }),
+		lalib::VecD<2>({ 0.8, 0.0 }),
+		lalib::VecD<2>({ 1.0, 0.0 })
+	});
+	
+	ASSERT_NEAR(0.1, curve.length(0.1), 1e-10);
+	ASSERT_NEAR(0.7, curve.length(0.7), 1e-10);
+}
+
 TEST_F(SplineTests, NumOfSegmentsTest) {
 	ASSERT_EQ(4, pline->n_segments());
 } 
@@ -66,7 +80,7 @@ TEST_F(SplineTests, InterpolationTest) {
     });
 	auto spline = geomlib::CubicSpline<2>(plist);
 
-	print_spline(spline, 50);
+	//print_spline(spline, 50);
 	
     ASSERT_DOUBLE_EQ(0.0, spline.point(0.0)[0]);
     ASSERT_DOUBLE_EQ(0.0, spline.point(0.0)[1]);

--- a/test/curve/cubic_spline.cc
+++ b/test/curve/cubic_spline.cc
@@ -1,6 +1,15 @@
 #include "../../include/curve/cubic_spline.hpp"
+#include <iostream>
 #include <numbers>
 #include <gtest/gtest.h>
+
+template<size_t N>
+void print_spline(const geomlib::CubicSpline<N>& spline, size_t n) noexcept {
+	for (auto i = 0u; i <= n; ++i) {
+		auto denom = static_cast<double>(n);
+		std::cout << spline.point(i / denom)[0] << ", " << spline.point(i / denom)[1] << std::endl;
+	}
+}
 
 class SplineTests: public ::testing::Test {
 protected:
@@ -38,6 +47,7 @@ TEST_F(SplineTests, NumOfSegmentsTest) {
 } 
 
 TEST_F(SplineTests, InterpolationTest) {
+	// Equal-spacing circle
 	EXPECT_NEAR(circle(0.0)[0], pline->point(0.0)[0], 1e-10);
 	EXPECT_NEAR(circle(0.0)[1], pline->point(0.0)[1], 1e-10);
 
@@ -46,6 +56,23 @@ TEST_F(SplineTests, InterpolationTest) {
 
 	EXPECT_NEAR(circle(1.0)[0], pline->point(1.0)[0], 1e-10);
 	EXPECT_NEAR(circle(1.0)[1], pline->point(1.0)[1], 1e-10);
+
+	// Unequal-spacing line
+	auto plist = std::vector<lalib::VecD<2>>({
+        lalib::VecD<2>({ 0.0, 0.0 }),
+        lalib::VecD<2>({ 0.5, 0.0 }),
+        lalib::VecD<2>({ 0.7, 0.0 }),
+        lalib::VecD<2>({ 1.0, 0.0 })
+    });
+	auto spline = geomlib::CubicSpline<2>(plist);
+
+	print_spline(spline, 50);
+	
+    ASSERT_DOUBLE_EQ(0.0, spline.point(0.0)[0]);
+    ASSERT_DOUBLE_EQ(0.0, spline.point(0.0)[1]);
+
+    ASSERT_DOUBLE_EQ(1.0, spline.point(1.0)[0]);
+    ASSERT_DOUBLE_EQ(0.0, spline.point(1.0)[1]);	
 }
 
 TEST_F(SplineTests, TangentTest) {

--- a/test/curve/polyline.cc
+++ b/test/curve/polyline.cc
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+#include "../../include/curve/polyline.hpp"
+
+TEST(PolylineTests, LengthTest) {
+	auto curve = geomlib::Polyline<2>({
+		lalib::VecD<2>({ 0.0, 0.0 }),
+		lalib::VecD<2>({ 0.2, 0.2 }),
+		lalib::VecD<2>({ 0.7, 0.7 }),
+		lalib::VecD<2>({ 1.0, 1.0 })
+	});
+	
+	ASSERT_NEAR(std::sqrt(2), curve.length(), 1e-10);
+}
+
+TEST(PolylineTests, NumOfSegmentTest) {
+	auto curve = geomlib::Polyline<2>({
+		lalib::VecD<2>({ 0.0, 0.0 }),
+		lalib::VecD<2>({ 0.2, 0.2 }),
+		lalib::VecD<2>({ 0.7, 0.7 }),
+		lalib::VecD<2>({ 1.0, 1.0 })
+	});
+	
+	ASSERT_EQ(3, curve.n_segments());
+}
+
+TEST(PolylineTests, InterPolationTest) {
+	auto curve = geomlib::Polyline<2>({
+		lalib::VecD<2>({ 0.0, 0.0 }),
+		lalib::VecD<2>({ 0.2, 0.2 }),
+		lalib::VecD<2>({ 0.7, 0.7 }),
+		lalib::VecD<2>({ 1.0, 1.0 })
+	});
+	
+    ASSERT_DOUBLE_EQ(0.0, curve.point(0.0)[0]);
+    ASSERT_DOUBLE_EQ(0.0, curve.point(0.0)[1]);
+
+    ASSERT_DOUBLE_EQ(0.5, curve.point(0.5)[0]);
+    ASSERT_DOUBLE_EQ(0.5, curve.point(0.5)[1]);
+
+    ASSERT_DOUBLE_EQ(1.0, curve.point(1.0)[0]);
+    ASSERT_DOUBLE_EQ(1.0, curve.point(1.0)[1]);
+}
+
+TEST(PolylineTests, TangentTest) {
+	auto curve = geomlib::Polyline<2>({
+		lalib::VecD<2>({ 0.0, 0.0 }),
+		lalib::VecD<2>({ 0.2, 0.2 }),
+		lalib::VecD<2>({ 0.7, 0.7 }),
+		lalib::VecD<2>({ 1.0, 1.0 })
+	});
+
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.0)[0]);
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.0)[1]);
+
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.1)[0]);
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.1)[1]);
+
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.5)[0]);
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.5)[1]);
+
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.7)[0]);
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.7)[1]);
+
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.9)[0]);
+	EXPECT_DOUBLE_EQ(1.0 / std::sqrt(2), curve.tangent(0.9)[1]);
+}
+
+TEST(PolylineTests, DerivationTest) {
+	auto curve = geomlib::Polyline<2>({
+		lalib::VecD<2>({ 0.0, 0.0 }),
+		lalib::VecD<2>({ 0.2, 0.2 }),
+		lalib::VecD<2>({ 0.7, 0.7 }),
+		lalib::VecD<2>({ 1.0, 1.0 })
+	});
+
+	EXPECT_DOUBLE_EQ(0.2 / sqrt(0.2*0.2 + 0.2*0.2), curve.tangent(0.0)[0]);
+	EXPECT_DOUBLE_EQ(0.2 / sqrt(0.2*0.2 + 0.2*0.2), curve.tangent(0.0)[1]);
+
+	EXPECT_DOUBLE_EQ(0.5 / (sqrt(0.7*0.7 + 0.7*0.7) - sqrt(0.2*0.2 + 0.2*0.2)), curve.tangent(0.5)[0]);
+	EXPECT_DOUBLE_EQ(0.5 / (sqrt(0.7*0.7 + 0.7*0.7) - sqrt(0.2*0.2 + 0.2*0.2)), curve.tangent(0.5)[1]);
+}


### PR DESCRIPTION
# Overview
This pull request introduces the polyline features and modifies some implementations of `CubicSpline`.
The polyline is the set of the line segment, which conforms to the `Curve` concept.

In the previous version, the member function for obtaining an intermediate point on the CubicSpline calculated the point such that the parametric variable s was approximately proportional to the length from the starting point of the spline. However, in cases of highly non-uniform node-to-node distances, the parametric variables did not remain proportional to the length from the starting point, as the sub-segment of the spline deviated significantly from a straight line. To enhance clarity for users, this update eliminates the approximation related to parametric variables.