### PR TITLE
Update some implementation of curve-types

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/lalib"]
 	path = third_party/lalib
 	url = https://github.com/Konishi2911/lalib.git
+[submodule "third_party/mathlib"]
+	path = third_party/mathlib
+	url = https://github.com/Konishi2911/mathlib.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(geomlib VERSION 0.3.0 LANGUAGES C CXX)
+project(geomlib VERSION 0.4.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/curve.hpp
+++ b/include/curve.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#ifndef GEOMLIB_CURVE_HPP
+#define GEOMLIB_CURVE_HPP
+
+#include "curve/curve_concepts.hpp"
+#include "curve/cubic_spline.hpp"
+#include "curve/polyline.hpp"
+#include "curve/segment.hpp"
+#include "../third_party/mathlib/include/roots/secant.hpp"
+
+namespace geomlib {
+
+/// @brief 
+/// @tparam F 
+/// @tparam N 
+/// @param spline 
+/// @param n 
+/// @param f 
+/// @return 
+template<std::invocable<double> F, size_t N>
+auto sample(const geomlib::CubicSpline<N>& spline, size_t n, F&& f) noexcept -> geomlib::Polyline<N> {
+    auto root_solver = mathlib::Secant(1e-8);
+    auto tot_len = spline.length();
+
+    auto vec = std::vector<lalib::VecD<N>>();
+    vec.reserve(n);
+    for (auto k = 0u; k < n; ++k) {
+        auto s = static_cast<double>(k) / (n - 1);
+        auto len = tot_len * f(s);
+        auto t = root_solver.find_root([&](double x){ return len - spline.length(x); }, 0.0, 1.0).value();
+
+        vec.emplace_back(spline.point(t));
+    }
+    auto polyline = Polyline<N>(vec);
+    return polyline;
+}
+
+
+}
+
+#endif

--- a/include/curve/polyline.hpp
+++ b/include/curve/polyline.hpp
@@ -218,7 +218,7 @@ inline Polyline<N>::SegmentViewIterator::SegmentViewIterator(const std::vector<P
 template <size_t N>
 inline auto Polyline<N>::SegmentViewIterator::sentinel(const std::vector<PointType> &nodes) noexcept -> SegmentViewIterator
 {
-    return SegmentViewIterator(nodes, nodes.size());
+    return SegmentViewIterator(nodes, nodes.size() - 1);
 }
 
 template <size_t N>

--- a/include/curve/segment.hpp
+++ b/include/curve/segment.hpp
@@ -8,12 +8,12 @@
 namespace geomlib {
 
 template<size_t N>
-struct Segment {
+struct SegmentView {
 public:
     using PointType = lalib::SizedVec<double, N>;
     using VectorType = lalib::SizedVec<double, N>;
 
-    Segment(const PointType& s, const PointType& e) noexcept;
+    SegmentView(const PointType& s, const PointType& e) noexcept;
 
 
     auto operator()(double s) const noexcept -> PointType;
@@ -34,15 +34,84 @@ public:
     auto tangent(double s) const noexcept -> VectorType;
 
 private:
+    const PointType& _ps;
+    const PointType& _pe;
+};
+
+template<size_t N>
+struct Segment {
+public:
+    using PointType = lalib::SizedVec<double, N>;
+    using VectorType = lalib::SizedVec<double, N>;
+
+    Segment(const PointType& s, const PointType& e) noexcept;
+    Segment(PointType&& s, PointType&& e) noexcept;
+
+    auto operator()(double s) const noexcept -> PointType;
+
+    /// @brief  Returns the point on the segment specified by the given local position `s`
+    /// @note   `s` is clamped with 0.0 or 1.0 if it is out of range.
+    /// @param s    local position `s` which range is [0.0, 1.0].
+    /// @return     a point on the segment
+    auto point(double s) const noexcept -> PointType;
+
+    /// @brief  Returns the length of the segment.
+    /// @return length of the segment
+    auto length() const noexcept -> double;
+
+    /// @brief  Returns the tangent vector
+    /// @param s 
+    /// @return 
+    auto tangent(double s) const noexcept -> VectorType;
+
+private:
     std::array<lalib::SizedVec<double, N>, 2> _p;
+    SegmentView<N> _segment_view;
 };
 
 
 // ==== Implementation ==== //
 
 template <size_t N>
+inline SegmentView<N>::SegmentView(const PointType &s, const PointType &e) noexcept:
+    _ps(s), _pe(e)
+{ }
+
+template <size_t N>
+inline auto SegmentView<N>::operator()(double s) const noexcept -> PointType
+{
+    return point(s);
+}
+
+template <size_t N>
+inline auto SegmentView<N>::point(double s) const noexcept -> PointType
+{
+    s = std::clamp(s, 0.0, 1.0);
+    auto p = s * this->_pe + (1.0 - s) * this->_ps;
+    return p;
+}
+template <size_t N>
+inline auto SegmentView<N>::length() const noexcept -> double
+{
+    auto length = (_pe - _ps).norm2();
+    return length;
+}
+template <size_t N>
+inline auto SegmentView<N>::tangent(double) const noexcept -> VectorType
+{
+    auto t = (_pe - _ps) / this->length();
+    return t;
+}
+
+
+template <size_t N>
 inline Segment<N>::Segment(const PointType &s, const PointType &e) noexcept:
-    _p({s, e})
+    _p({s, e}), _segment_view(_p[0], _p[1])
+{ }
+
+template <size_t N>
+inline Segment<N>::Segment(PointType &&s, PointType &&e) noexcept:
+    _p({std::move(s), std::move(e)}), _segment_view(_p[0], _p[1])
 { }
 
 template <size_t N>
@@ -54,21 +123,17 @@ inline auto Segment<N>::operator()(double s) const noexcept -> PointType
 template <size_t N>
 inline auto Segment<N>::point(double s) const noexcept -> PointType
 {
-    s = std::clamp(s, 0.0, 1.0);
-    auto p = s * this->_p[1] + (1.0 - s) * this->_p[0];
-    return p;
+    return this->_segment_view.point(s);
 }
 template <size_t N>
 inline auto Segment<N>::length() const noexcept -> double
 {
-    auto length = (_p[1] - _p[0]).norm2();
-    return length;
+    return this->_segment_view.length();
 }
 template <size_t N>
-inline auto Segment<N>::tangent(double) const noexcept -> VectorType
+inline auto Segment<N>::tangent(double s) const noexcept -> VectorType
 {
-    auto t = (_p[1] - _p[0]) / this->length();
-    return t;
+    return this->_segment_view.tangent(s);
 }
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,3 +13,7 @@ gtest_discover_tests(polyline_test)
 add_executable(affine_test ./affine.cc)
 target_link_libraries(affine_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
 gtest_discover_tests(affine_test)
+
+add_executable(curve_common_test ./curve_common.cc)
+target_link_libraries(curve_common_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
+gtest_discover_tests(curve_common_test)

--- a/test/curve/polyline.cc
+++ b/test/curve/polyline.cc
@@ -1,5 +1,10 @@
 #include <gtest/gtest.h>
+#include <ranges>
 #include "../../include/curve/polyline.hpp"
+
+static_assert(std::input_iterator<geomlib::Polyline<2>::SegmentViewIterator>);
+static_assert(std::sentinel_for<geomlib::Polyline<2>::SegmentViewIterator, geomlib::Polyline<2>::SegmentViewIterator>);
+static_assert(std::ranges::input_range<geomlib::Polyline<2>>);
 
 TEST(PolylineTests, LengthTest) {
 	auto curve = geomlib::Polyline<2>({
@@ -21,6 +26,27 @@ TEST(PolylineTests, NumOfSegmentTest) {
 	});
 	
 	ASSERT_EQ(3, curve.n_segments());
+}
+
+TEST(PolylineTests, SegmentIterationTest) {
+	auto plist = std::vector({
+		lalib::VecD<2>({ 0.0, 0.0 }),
+		lalib::VecD<2>({ 0.2, 0.2 }),
+		lalib::VecD<2>({ 0.7, 0.7 }),
+		lalib::VecD<2>({ 1.0, 1.0 })
+	});
+	auto curve = geomlib::Polyline<2>(plist);
+
+	auto i = 0u;
+	for (auto&& seg: curve) {
+		ASSERT_DOUBLE_EQ(seg.point(0.0)[0], plist[i][0]);
+		ASSERT_DOUBLE_EQ(seg.point(0.0)[1], plist[i][1]);
+
+		ASSERT_DOUBLE_EQ(seg.point(1.0)[0], plist[i + 1][0]);
+		ASSERT_DOUBLE_EQ(seg.point(1.0)[1], plist[i + 1][1]);
+
+		++i;
+	}
 }
 
 TEST(PolylineTests, InterPolationTest) {

--- a/test/curve_common.cc
+++ b/test/curve_common.cc
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+#include <functional>
+#include "../include/curve.hpp"
+
+TEST(CurveCommonTests, ResamplingTest) {
+    auto plist = std::vector {
+        lalib::VecD<2>({ 0.0, 0.0 }),
+        lalib::VecD<2>({ 0.2, 0.0 }),
+        lalib::VecD<2>({ 0.5, 0.0 }),
+        lalib::VecD<2>({ 1.0, 0.0 }),
+    };
+    auto spline = geomlib::CubicSpline<2>(plist);
+    auto sampled = geomlib::sample(spline, 11, std::identity());
+
+    for (auto&& seg: sampled) {
+        EXPECT_NEAR(seg.length(), 0.1, 1e-6);
+    }
+}


### PR DESCRIPTION
# Overview
This pull request introduces a new type, `SegmentView`, which provides certain member functions similar to `Segment` except for having ownership of node information.
This update also includes modifications to the implementation of curve types, specifically `Segment` and `Polyline`.
The `Segment` has been updated with the backend routines now delegated to `SegmentView`.The new member functions to the `Polyline` and associated iterator type are introduced to conform to the concept `input_range`.

The external library https://github.com/Konishi2911/mathlib.git has been introduced in this update.