### PR TITLE
Improve APIs regarding the affine transformation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(geomlib VERSION 0.4.2 LANGUAGES C CXX)
+project(geomlib VERSION 0.5.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         source: './'
         target: '/home/geomlib'
     command: >
-      bash -c "cd /home/lalib && 
+      bash -c "cd /home/geomlib && 
       cmake -B ../build_gcc10 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DLALIB_BACKEND=Internal &&
       cmake -B ../build_gcc10_blas -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DLALIB_BACKEND=BLAS &&
       cmake -B ../build_gcc10_lapack -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DLALIB_BACKEND=LAPACK &&

--- a/include/affine.hpp
+++ b/include/affine.hpp
@@ -33,6 +33,8 @@ public:
     auto point(double s) const noexcept -> PointType;
     auto tangent(double s) const noexcept -> VectorType;
 
+    auto native() const noexcept -> C requires AffineTransformable<C, N>;
+
 private:
     C _curve;
     Affine<N> _affine;
@@ -164,6 +166,13 @@ inline auto AffineTransformedCurve<C, N>::tangent(double s) const noexcept -> Ve
     auto tan = this->_curve.tangent(s);
     auto trans_tan = this->_affine.transform(tan);
     return trans_tan;
+}
+
+template <Curve C, size_t N>
+inline auto AffineTransformedCurve<C, N>::native() const noexcept -> C
+requires AffineTransformable<C, N>
+{
+    auto native = this->_curve.transformed(this->_affine)
 }
 }
 

--- a/include/curve/polyline.hpp
+++ b/include/curve/polyline.hpp
@@ -3,6 +3,7 @@
 #define GEOMLIB_CURVE_POLYLINE_HPP
 
 #include "../../third_party/lalib/include/vec.hpp"
+#include "../affine/affine_core.hpp"
 #include "segment.hpp"
 #include <array>
 #include <vector>
@@ -72,6 +73,10 @@ public:
     /// @param s 
     /// @return 
     auto tangent(double s) const noexcept -> VectorType;
+
+    auto transform(const Affine<N>& affine) noexcept -> Polyline<N>&;
+
+    auto transformed(const Affine<N>& affine) const noexcept -> Polyline<N>;
 
 private:
     std::vector<double> _cumul_length;
@@ -149,6 +154,24 @@ inline auto Polyline<N>::tangent(double s) const noexcept -> VectorType
     auto dp = this->dp(s);
     dp = dp / dp.norm2();
     return dp;
+}
+
+template <size_t N>
+inline auto Polyline<N>::transform(const Affine<N> &affine) noexcept -> Polyline &
+{
+    auto n = this->_nodes.size();
+    for (auto i = 0u; i < n; ++i) {
+        affine.transform(this->_nodes[i]);
+    }
+    this->_cumul_length = __calc_cumul_length(this->_nodes);
+    return *this;
+}
+
+template <size_t N>
+inline auto Polyline<N>::transformed(const Affine<N> &affine) const noexcept -> Polyline
+{
+    auto polyline = Polyline(*this).transform(affine);
+    return polyline;
 }
 
 template <size_t N>

--- a/include/curve/polyline.hpp
+++ b/include/curve/polyline.hpp
@@ -7,6 +7,7 @@
 #include "segment.hpp"
 #include <array>
 #include <vector>
+#include <optional>
 #include <cassert>
 
 namespace geomlib {

--- a/test/affine.cc
+++ b/test/affine.cc
@@ -130,3 +130,23 @@ TEST(AffineTests, CompositeTest) {
     ASSERT_DOUBLE_EQ(1.0, p[0]);
     ASSERT_DOUBLE_EQ(1.0, p[1]);
 }
+
+
+TEST(AffineTransformedCurveTests, MultipleTransformationTest) {
+    auto curve = geomlib::Segment<2>(
+        lalib::VecD<2>({0.0, 0.0}),
+        lalib::VecD<2>({2.0, 0.0})
+    );
+    auto affine = geomlib::rotate2d(std::numbers::pi / 4.0, lalib::VecD<2>::filled(0.0));
+
+	static_assert(geomlib::AffineTransformableCurve<decltype(curve), 2>);
+
+    auto transformed_curve = geomlib::transform_lazy(std::move(curve), std::move(affine));
+    transformed_curve = geomlib::transform_lazy(std::move(transformed_curve), std::move(affine));
+
+    EXPECT_DOUBLE_EQ(0.0, transformed_curve.point(0.0)[0]);
+    EXPECT_DOUBLE_EQ(0.0, transformed_curve.point(0.0)[1]);
+
+    EXPECT_NEAR(0.0, transformed_curve.point(1.0)[0], 1e-10);
+    EXPECT_NEAR(2.0, transformed_curve.point(1.0)[1], 1e-10); 
+}

--- a/test/curve/cubic_spline.cc
+++ b/test/curve/cubic_spline.cc
@@ -1,4 +1,5 @@
 #include "../../include/curve/cubic_spline.hpp"
+#include "../../include/affine.hpp"
 #include <iostream>
 #include <numbers>
 #include <gtest/gtest.h>
@@ -126,4 +127,27 @@ TEST_F(SplineTests, DerivationTest) {
 
 	EXPECT_DOUBLE_EQ(0.5 / (sqrt(0.7*0.7 + 0.7*0.7) - sqrt(0.2*0.2 + 0.2*0.2)), curve.tangent(0.5)[0]);
 	EXPECT_DOUBLE_EQ(0.5 / (sqrt(0.7*0.7 + 0.7*0.7) - sqrt(0.2*0.2 + 0.2*0.2)), curve.tangent(0.5)[1]);
+}
+
+TEST_F(SplineTests, AffineTransformationTest) {
+	auto curve = geomlib::CubicSpline<2>({
+		lalib::VecD<2>({ 0.0, 0.0 }),
+		lalib::VecD<2>({ 0.2, 0.2 }),
+		lalib::VecD<2>({ 0.7, 0.7 }),
+		lalib::VecD<2>({ 1.0, 1.0 })
+	});
+	
+	auto affine = geomlib::rotate2d(std::numbers::pi / 4.0, lalib::VecD<2>::filled(0.0));
+	auto half_scale = geomlib::Affine(lalib::MatD<2, 2>({
+		0.5, 0.0,
+		0.0, 0.5
+	}), lalib::VecD<2>::filled(0.0));
+
+	static_assert(geomlib::AffineTransformableCurve<decltype(curve), 2>);
+
+	curve.transform(affine);
+	ASSERT_NEAR(std::sqrt(2), curve.length(), 1e-10);
+
+	auto half_curve = curve.transformed(half_scale);
+	ASSERT_NEAR(std::sqrt(2) / 2.0, half_curve.length(), 1e-10);
 }

--- a/test/curve/polyline.cc
+++ b/test/curve/polyline.cc
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <ranges>
+#include <numbers>
 #include "../../include/curve/polyline.hpp"
+#include "../../include/affine.hpp"
 
 static_assert(std::input_iterator<geomlib::Polyline<2>::SegmentViewIterator>);
 static_assert(std::sentinel_for<geomlib::Polyline<2>::SegmentViewIterator, geomlib::Polyline<2>::SegmentViewIterator>);
@@ -119,4 +121,26 @@ TEST(PolylineTests, DerivationTest) {
 
 	EXPECT_DOUBLE_EQ(0.5 / (sqrt(0.7*0.7 + 0.7*0.7) - sqrt(0.2*0.2 + 0.2*0.2)), curve.tangent(0.5)[0]);
 	EXPECT_DOUBLE_EQ(0.5 / (sqrt(0.7*0.7 + 0.7*0.7) - sqrt(0.2*0.2 + 0.2*0.2)), curve.tangent(0.5)[1]);
+}
+
+TEST(PolylineTests, AffineTransformationTest) {
+	auto curve = geomlib::Polyline<2>({
+		lalib::VecD<2>({ 0.0, 0.0 }),
+		lalib::VecD<2>({ 0.2, 0.2 }),
+		lalib::VecD<2>({ 0.7, 0.7 }),
+		lalib::VecD<2>({ 1.0, 1.0 })
+	});
+	auto affine = geomlib::rotate2d(std::numbers::pi / 4.0, lalib::VecD<2>::filled(0.0));
+	auto half_scale = geomlib::Affine(lalib::MatD<2, 2>({
+		0.5, 0.0,
+		0.0, 0.5
+	}), lalib::VecD<2>::filled(0.0));
+
+	static_assert(geomlib::AffineTransformableCurve<decltype(curve), 2>);
+
+	curve.transform(affine);
+	ASSERT_NEAR(std::sqrt(2), curve.length(), 1e-10);
+
+	auto half_curve = curve.transformed(half_scale);
+	ASSERT_NEAR(std::sqrt(2) / 2.0, half_curve.length(), 1e-10);
 }


### PR DESCRIPTION
# Overview
This pill request adds and modifies some APIs around the feature of affine transformation.

# Added or modified features
### New non-member function
* `scale` creates an affine transformation object representing isotropic scaling.

### API changes
* rename `AffineTransformable` to `AffineTransformableCurve`

### New conformances to the concept `AffineTransformableCurve`
* `Polyline`
* `CubicSpline`
* `AffineTransformedCurve`
