### PR TITLE
Add some member functions to Segment and Polygon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(geomlib VERSION 0.9.0 LANGUAGES C CXX)
+project(geomlib VERSION 0.9.1 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/geomlib/curve/segment.hpp
+++ b/include/geomlib/curve/segment.hpp
@@ -1,5 +1,4 @@
 #pragma once 
-#include <cstdint>
 #ifndef GEOMLIB_SEGMENT_HPP
 #define GEOMLIB_SEGMENT_HPP
 

--- a/include/geomlib/curve/segment.hpp
+++ b/include/geomlib/curve/segment.hpp
@@ -52,6 +52,13 @@ public:
     /// @param query    query point
     auto distance(const VectorType& query) const noexcept -> double;
 
+    /// @brief calculates a foot of a perpendicular
+    auto foot(const VectorType& query) const noexcept -> VectorType;
+
+    /// @brief checks if this segment includes the query point
+    auto check_inclusion(const VectorType& query) const noexcept -> bool;
+
+
 private:
     std::reference_wrapper<const PointType> _ps;
     std::reference_wrapper<const PointType> _pe;
@@ -103,6 +110,13 @@ public:
     /// @brief calculates the minimum distance to the query point
     /// @param query    query point
     auto distance(const VectorType& query) const noexcept -> double;
+
+    /// @brief calculates a foot of a perpendicular
+    auto foot(const VectorType& query) const noexcept -> VectorType;
+
+    /// @brief checks if this segment includes the query point
+    /// @note   This function DO NOT check whether the query point is on the line belonging to this segment.
+    auto check_inclusion(const VectorType& query) const noexcept -> bool;
 
 private:
     std::array<lalib::SizedVec<double, N>, 2> _p;
@@ -183,6 +197,19 @@ inline auto SegmentView<N>::distance(const VectorType &query) const noexcept -> 
     }
 }
 
+template<size_t N>
+inline auto SegmentView<N>::foot(const VectorType& query) const noexcept -> VectorType {
+    auto v = this->tangent(0.0);
+    auto pf = this->_ps.get() + ((query - this->_ps.get()).dot(v)) * v;
+    return pf;
+}
+
+template<size_t N>
+inline auto SegmentView<N>::check_inclusion(const VectorType& query) const noexcept -> bool {
+    auto sign = (query - this->_ps.get()).dot(query - this->_pe.get());
+    return sign < 0;
+}
+
 template <size_t N>
 inline Segment<N>::Segment(const PointType &s, const PointType &e) noexcept:
     _p({s, e}), _segment_view(_p[0], _p[1])
@@ -243,6 +270,16 @@ template <size_t N>
 inline auto Segment<N>::distance(const VectorType &query) const noexcept -> double
 {
     return this->_segment_view.distance(query);
+}
+
+template<size_t N>
+inline auto Segment<N>::foot(const VectorType& query) const noexcept -> VectorType {
+    return this->_segment_view.foot(query);
+}
+
+template<size_t N>
+inline auto Segment<N>::check_inclusion(const VectorType& query) const noexcept -> bool {
+    return this->_segment_view.check_inclusion(query);
 }
 }
 

--- a/include/geomlib/curve/segment.hpp
+++ b/include/geomlib/curve/segment.hpp
@@ -1,4 +1,5 @@
 #pragma once 
+#include <cstdint>
 #ifndef GEOMLIB_SEGMENT_HPP
 #define GEOMLIB_SEGMENT_HPP
 
@@ -55,7 +56,11 @@ public:
     /// @brief calculates a foot of a perpendicular
     auto foot(const VectorType& query) const noexcept -> VectorType;
 
+    /// @brief calculates the position in the local coordinate from the given point
+    auto local(const VectorType& query) const noexcept -> double;
+
     /// @brief checks if this segment includes the query point
+    /// @note   This function DO NOT check whether the query point is on the line belonging to this segment.
     auto check_inclusion(const VectorType& query) const noexcept -> bool;
 
 
@@ -113,6 +118,9 @@ public:
 
     /// @brief calculates a foot of a perpendicular
     auto foot(const VectorType& query) const noexcept -> VectorType;
+
+    /// @brief calculates the position in the local coordinate from the given point
+    auto local(const VectorType& query) const noexcept -> double;
 
     /// @brief checks if this segment includes the query point
     /// @note   This function DO NOT check whether the query point is on the line belonging to this segment.
@@ -205,6 +213,12 @@ inline auto SegmentView<N>::foot(const VectorType& query) const noexcept -> Vect
 }
 
 template<size_t N>
+inline auto SegmentView<N>::local(const VectorType& query) const noexcept -> double {
+    auto s = (query - this->_ps.get()).dot(this->tangent(0.0)) / this->length();
+    return s;
+}
+
+template<size_t N>
 inline auto SegmentView<N>::check_inclusion(const VectorType& query) const noexcept -> bool {
     auto sign = (query - this->_ps.get()).dot(query - this->_pe.get());
     return sign < 0;
@@ -275,6 +289,11 @@ inline auto Segment<N>::distance(const VectorType &query) const noexcept -> doub
 template<size_t N>
 inline auto Segment<N>::foot(const VectorType& query) const noexcept -> VectorType {
     return this->_segment_view.foot(query);
+}
+
+template<size_t N>
+inline auto Segment<N>::local(const VectorType& query) const noexcept -> double {
+    return this->_segment_view.local(query);
 }
 
 template<size_t N>

--- a/include/geomlib/nns/kd_tree.hpp
+++ b/include/geomlib/nns/kd_tree.hpp
@@ -24,7 +24,7 @@ public:
 	class Node;
 	enum class Child { Left, Right };
 
-	KdTree(std::vector<T>&& nodes, Proj&& proj = {}) noexcept: _nodes( __construct(std::move(nodes), std::move(proj)) ), _proj(proj) {}  
+	KdTree(std::vector<T>&& nodes, Proj&& proj = {}) noexcept: _nodes( __construct(std::move(nodes), proj) ), _proj(std::move(proj)) {}  
 
 	auto size() const noexcept -> size_t;
 
@@ -42,7 +42,7 @@ private:
 
 	auto __get_entry_point() const noexcept -> std::weak_ptr<Node> { return this->_nodes.back(); }
 
-	static auto __construct(std::vector<T>&& nodes, Proj proj) noexcept -> std::vector<std::shared_ptr<Node>>;
+	static auto __construct(std::vector<T>&& nodes, const Proj& proj) noexcept -> std::vector<std::shared_ptr<Node>>;
 	static auto __distance(std::weak_ptr<Node> node, const V& query, Proj proj) noexcept -> double;
 	static auto __get_leaf(std::weak_ptr<Node> node, const V& query, std::stack<std::pair<Child, std::weak_ptr<Node>>>& stack) noexcept -> std::weak_ptr<Node>;
 };
@@ -205,7 +205,7 @@ auto KdTree<T, N, V, Proj>::radius_search(const V& query, double radius) const n
 }
 
 template<typename T, size_t N, typename V, class Proj>
-auto KdTree<T, N, V, Proj>::__construct(std::vector<T>&& values, Proj proj) noexcept -> std::vector<std::shared_ptr<Node>> {
+auto KdTree<T, N, V, Proj>::__construct(std::vector<T>&& values, const Proj& proj) noexcept -> std::vector<std::shared_ptr<Node>> {
 	auto nodes = std::vector<std::shared_ptr<Node>>();
 	auto indices = std::vector<size_t>(values.size(), 0);
 	std::iota(indices.begin(), indices.end(), 0);

--- a/include/geomlib/surface/polygon.hpp
+++ b/include/geomlib/surface/polygon.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include "geomlib/surface/surface_concepts.hpp"
 #ifndef GEOMLIB_SURFACE_POLYGON_HPP
 #define GEOMLIB_SURFACE_POLYGON_HPP
 
+#include "geomlib/surface/surface_concepts.hpp"
+#include "lalib/ops/vec_ops.hpp"
 #include "lalib/vec.hpp"
 #include "lalib/mat.hpp"
 #include <functional>
@@ -22,6 +23,12 @@ struct Polygon {
     auto origin() const noexcept -> PointType;
     auto area() const noexcept -> double;
     auto base() const noexcept -> lalib::MatD<3, 2>;
+
+    /// @brief Calculates a foot of a perpendicular
+    auto foot(const lalib::VecD<3>& query) const noexcept -> lalib::VecD<3>;
+
+    /// @brief Checks inclusion of the point
+    auto check_inclusion(const lalib::VecD<3>& query) const noexcept -> bool;
 
 private:
     std::vector<PointType> _verts;
@@ -44,6 +51,13 @@ struct PolygonView {
     auto origin() const noexcept -> PointType;
     auto area() const noexcept -> double;
     auto base() const noexcept -> lalib::MatD<3, 2>;
+
+    /// @brief Calculates a foot of a perpendicular
+    auto foot(const lalib::VecD<3>& query) const noexcept -> lalib::VecD<3>;
+
+    /// @brief  Checks if the query point is inside of the polygon
+    /// @note   This function DO NOT check whether the query point is on the plane belonging to this polygon.
+    auto check_inclusion(const lalib::VecD<3>& query) const noexcept -> bool;
 
 private:
     std::vector<std::reference_wrapper<const PointType>> _verts;
@@ -100,6 +114,25 @@ inline auto Polygon::base() const noexcept -> lalib::MatD<3, 2> {
         this->_base[0][2], this->_base[1][2]
     });
     return base;
+}
+
+inline auto Polygon::foot(const lalib::VecD<3>& query) const noexcept -> lalib::VecD<3> {
+    auto pf = query - (query - this->_verts[0]).dot(this->normal()) * this->normal();
+    return pf;
+}
+
+inline auto Polygon::check_inclusion(const lalib::VecD<3>& query) const noexcept -> bool {
+    auto l0 = (this->_verts[1] - this->_verts[0]);
+    auto cross0 = lalib::cross(query - this->_verts[0], l0);
+    auto n = this->_verts.size();
+
+    bool check = true;
+    for (auto i = 1u; i < n; ++i) {
+        auto l = this->_verts[(i + 1) % n] - this->_verts[i];
+        auto cross = lalib::cross(query - this->_verts[i], l);
+        check &= cross0.dot(cross) > 0;
+    }
+    return check;
 }
 
 
@@ -160,6 +193,25 @@ inline auto PolygonView::base() const noexcept -> lalib::MatD<3, 2> {
         this->_base[0][2], this->_base[1][2]
     });
     return base;
+}
+
+inline auto PolygonView::foot(const lalib::VecD<3>& query) const noexcept -> lalib::VecD<3> {
+    auto pf = query - (query - this->_verts[0].get()).dot(this->normal()) * this->normal();
+    return pf;
+}
+
+inline auto PolygonView::check_inclusion(const lalib::VecD<3>& query) const noexcept -> bool {
+    auto l0 = (this->_verts[1].get() - this->_verts[0].get());
+    auto cross0 = lalib::cross(query - this->_verts[0].get(), l0);
+    auto n = this->_verts.size();
+
+    bool check = true;
+    for (auto i = 1u; i < n; ++i) {
+        auto l = this->_verts[(i + 1) % n].get() - this->_verts[i].get();
+        auto cross = lalib::cross(query - this->_verts[i].get(), l);
+        check &= cross0.dot(cross) > 0;
+    }
+    return check;
 }
 
 

--- a/test/curve/segment.cc
+++ b/test/curve/segment.cc
@@ -70,6 +70,17 @@ TEST(SegmentTests, FootTest) {
     EXPECT_DOUBLE_EQ(0.0, foot1[1]);
 }
 
+TEST(SegmentTests, LocalConversionTest) {
+    auto sp = lalib::VecD<2>({0.0, 0.0});
+    auto ep = lalib::VecD<2>({2.0, 0.0});
+    auto seg = geomlib::Segment(sp, ep);
+
+    auto query = lalib::VecD<2>({ 0.7, 0.0 });
+    auto local = seg.local(query);
+    
+    EXPECT_DOUBLE_EQ(0.35, local);
+}
+
 TEST(SegmentTests, InclusionTest) {
     auto sp = lalib::VecD<2>({0.0, 0.0});
     auto ep = lalib::VecD<2>({1.0, 0.0});

--- a/test/curve/segment.cc
+++ b/test/curve/segment.cc
@@ -58,6 +58,30 @@ TEST(SegmentTests, DistanceTest) {
     EXPECT_DOUBLE_EQ(std::sqrt(2.0), seg.distance(q3));
 }
 
+TEST(SegmentTests, FootTest) {
+    auto sp = lalib::VecD<2>({0.0, 0.0});
+    auto ep = lalib::VecD<2>({1.0, 0.0});
+    auto seg = geomlib::Segment(sp, ep);
+
+    auto q1 = lalib::VecD<2>({ 0.2, 2.0 });
+    auto foot1 = seg.foot(q1);
+    
+    EXPECT_DOUBLE_EQ(0.2, foot1[0]);
+    EXPECT_DOUBLE_EQ(0.0, foot1[1]);
+}
+
+TEST(SegmentTests, InclusionTest) {
+    auto sp = lalib::VecD<2>({0.0, 0.0});
+    auto ep = lalib::VecD<2>({1.0, 0.0});
+    auto seg = geomlib::Segment(sp, ep);
+
+    auto q1 = lalib::VecD<2>({ 0.5, 0.0});
+    auto q2 = lalib::VecD<2>({ 1.1, 0.0});
+
+    EXPECT_TRUE(seg.check_inclusion(q1));
+    EXPECT_FALSE(seg.check_inclusion(q2));
+}
+
 TEST(SegmentTests, AffineTransformationTest) {
     auto sp = lalib::VecD<3>({0.0, 1.0, 2.0});
     auto ep = lalib::VecD<3>({2.0, 4.0, 1.0});

--- a/test/surface/polygon.cc
+++ b/test/surface/polygon.cc
@@ -117,6 +117,23 @@ TEST_F(PolygonTests, AreaTest) {
     EXPECT_DOUBLE_EQ(2.0, penta->area());
 }
 
+TEST_F(PolygonTests, FootTest) {
+    auto query = lalib::VecD<3>({ 1.0, 0.5, 0.5 });
+    auto foot = rect->foot(query);
+
+    EXPECT_DOUBLE_EQ(0.0, foot[0]);
+    EXPECT_DOUBLE_EQ(0.5, foot[1]);
+    EXPECT_DOUBLE_EQ(0.5, foot[2]);
+}
+
+TEST_F(PolygonTests, InclusionTest) {
+    auto query1 = lalib::VecD<3>({ 0.0, 0.5, 0.5 });
+    auto query2 = lalib::VecD<3>({ 0.0, 2.0, 0.5 });
+
+    EXPECT_TRUE(rect->check_inclusion(query1));
+    EXPECT_FALSE(rect->check_inclusion(query2));
+}
+
 TEST_F(PolygonViewTests, PointTest) {
     auto rand = std::mt19937(std::random_device()());
     auto rng = std::uniform_real_distribution<double>(0.0, 1.0);
@@ -160,4 +177,21 @@ TEST_F(PolygonViewTests, AreaTest) {
     EXPECT_DOUBLE_EQ(1.0, tri->area());
     EXPECT_DOUBLE_EQ(1.0, rect->area());
     EXPECT_DOUBLE_EQ(2.0, penta->area());
+}
+
+TEST_F(PolygonViewTests, FootTest) {
+    auto query = lalib::VecD<3>({ 1.0, 0.5, 0.5 });
+    auto foot = rect->foot(query);
+
+    EXPECT_DOUBLE_EQ(0.0, foot[0]);
+    EXPECT_DOUBLE_EQ(0.5, foot[1]);
+    EXPECT_DOUBLE_EQ(0.5, foot[2]);
+}
+
+TEST_F(PolygonViewTests, InclusionTest) {
+    auto query1 = lalib::VecD<3>({ 0.0, 0.5, 0.5 });
+    auto query2 = lalib::VecD<3>({ 0.0, 2.0, 0.5 });
+
+    EXPECT_TRUE(rect->check_inclusion(query1));
+    EXPECT_FALSE(rect->check_inclusion(query2));
 }

--- a/test/surface/polygon.cc
+++ b/test/surface/polygon.cc
@@ -126,6 +126,14 @@ TEST_F(PolygonTests, FootTest) {
     EXPECT_DOUBLE_EQ(0.5, foot[2]);
 }
 
+TEST_F(PolygonTests, LocalConversionTest) {
+    auto query = lalib::VecD<3>({ 0.0, 0.5, 0.5 });
+    auto local = rect->local(query);
+
+    EXPECT_DOUBLE_EQ(0.5, local[0]);
+    EXPECT_DOUBLE_EQ(0.5, local[1]);
+}
+
 TEST_F(PolygonTests, InclusionTest) {
     auto query1 = lalib::VecD<3>({ 0.0, 0.5, 0.5 });
     auto query2 = lalib::VecD<3>({ 0.0, 2.0, 0.5 });
@@ -186,6 +194,14 @@ TEST_F(PolygonViewTests, FootTest) {
     EXPECT_DOUBLE_EQ(0.0, foot[0]);
     EXPECT_DOUBLE_EQ(0.5, foot[1]);
     EXPECT_DOUBLE_EQ(0.5, foot[2]);
+}
+
+TEST_F(PolygonViewTests, LocalConversionTest) {
+    auto query = lalib::VecD<3>({ 1.0, 0.5, 0.5 });
+    auto local = rect->local(query);
+
+    EXPECT_DOUBLE_EQ(0.5, local[0]);
+    EXPECT_DOUBLE_EQ(0.5, local[1]);
 }
 
 TEST_F(PolygonViewTests, InclusionTest) {


### PR DESCRIPTION
# Overview
This pull request adds the following member functions related to the geometric operation to the Segment and Polygon.
* `foot(query)`: calculates a foot of a perpendicular from the query point to the segment or polygon.
* `local(query)`: converts the coordinate of the given query point into the local coordinate of the segment or polygon.
* `check_inclusion(query)`: checks if the segment or polygon includes the given query point.

> [!NOTE]
> `local(_)` and `check_inclusion(_)` functions assume the query point is on the segment or polygon but these function DO NOT check whether the query is on it. Make sure that the query point is on the segment or polygon by caller.